### PR TITLE
feat: support HEAD requests

### DIFF
--- a/internal/http.go
+++ b/internal/http.go
@@ -44,6 +44,7 @@ func InitHTTP(config HTTPConfig, controller *FileController) {
 	}
 	router.GET("/healthz", health)
 	router.GET("/bucketrepo/*filepath", auth(controller.GetFile, config))
+	router.HEAD("/bucketrepo/*filepath", auth(controller.GetFile, config))
 	router.PUT("/bucketrepo/*filepath", auth(controller.PutFile, config))
 
 	log.Infof("Starting http server on %q", config.Address)


### PR DESCRIPTION
When using bucketrepo with Maven 3 I get build failures like the one below:
```
10:26:47 [ERROR] Failed to execute goal on project XXX: Could not resolve dependencies for project XXX-SNAPSHOT: Failed to collect dependencies at XXX: Failed to read artifact descriptor for XXX: Could not transfer artifact XXX from/to XXX (http://localhost:8080/bucketrepo/): Failed to transfer file: http://localhost:8080/bucketrepo/XXX.pom. Return code is: 405, ReasonPhrase: Method Not Allowed. -> [Help 1]
```

It looks like Maven is also using `HEAD` requests in addition to the already supported `GET` and `PUT` requests when retrieving files, so it would be great if bucketrepo could also implement them.
This PR is a proposal how it could be achieved without too much code duplication - I already use that in CI and it proved to work.