### PR TITLE
fix: run as an unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:latest  
-RUN apk --no-cache add ca-certificates
-COPY ./config/config.yaml /
-COPY ./bin/ /
-ENTRYPOINT ["/bucketrepo"]
+FROM gcr.io/distroless/base:nonroot
+COPY ./config/config.yaml /home/nonroot/
+COPY ./bin /home/nonroot/
+CMD ["/home/nonroot/bucketrepo"]


### PR DESCRIPTION
This changes the Dockerfile so that bucketrepo can run as an unprivileged user.

I went for [distroless](https://github.com/GoogleContainerTools/distroless) as it already includes a ca-certificates and the `/tmp` directory.