### PR TITLE
fix: copy files using `--chown`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/distroless/base:nonroot
-COPY ./config/config.yaml /home/nonroot/
-COPY ./bin /home/nonroot/
+
+COPY --chown=nonroot:nonroot ./config/config.yaml ./
+COPY --chown=nonroot:nonroot ./bin ./
 CMD ["/home/nonroot/bucketrepo"]

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     release:
       pipeline:
         agent:
-          image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+          image: gcr.io/kaniko-project/executor:v1.2.0
         stages:
         - name: release
           environment:
@@ -63,11 +63,11 @@ pipelineConfig:
             - all
 
           - name: build-and-push-image
-            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+            image: gcr.io/kaniko-project/executor:v1.2.0
             command: /kaniko/executor
-            args: 
+            args:
             - --dockerfile=/workspace/source/Dockerfile
-            - --destination=gcr.io/jenkinsxio/bucketrepo:${inputs.params.version} 
+            - --destination=gcr.io/jenkinsxio/bucketrepo:${inputs.params.version}
             - --destination=gcr.io/jenkinsxio/bucketrepo:latest
             - --context=/workspace/source
             - --cache-dir=/workspace
@@ -89,7 +89,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+          image: gcr.io/kaniko-project/executor:v1.2.0
         stages:
         - name: ci
           environment:
@@ -132,11 +132,11 @@ pipelineConfig:
           - name: make-all
             image: gcr.io/jenkinsxio/builder-go:0.1.734
             command: make
-            args: 
+            args:
             - all
 
           - name: build-and-push-image
-            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+            image: gcr.io/kaniko-project/executor:v1.2.0
             command: /kaniko/executor
             args:
             - --dockerfile=/workspace/source/Dockerfile


### PR DESCRIPTION
Another weird Kaniko behaviour I've encountered - if we copy the binary and config without using `--chown`, they'll be (along with the home directory) owned by root even though the base container already switched to a non-root user.

I didn't notice that, because Docker behaves a bit differently and I was foolishly building with Docker when testing locally.

In order to fix this, I also needed to upgrade Kaniko, because the version this repo was using did not support `--chown`.

If I change the base image to `debug-nonroot` and run the container with entrypoint set to `sh`, I see this:

**Kaniko v1.2.0**
```
~ $ id
uid=65532(nonroot) gid=65532(nonroot)
~ $ pwd
/home/nonroot
~ $ ls -lah
total 27M
drwxr-xr-x    1 nonroot  nonroot     4.0K Oct  7 08:25 .
drwxr-xr-x    1 nonroot  nonroot     4.0K Oct  7 08:24 ..
-rw-------    1 nonroot  nonroot       15 Oct  7 08:25 .ash_history
-rwxr-xr-x    1 nonroot  nonroot    27.2M Oct  7 08:24 bucketrepo
-rw-r--r--    1 nonroot  nonroot      279 Oct  7 08:24 config.yaml
```

**Kaniko at 9912ccbf8d22bbafbf971124600fbb0b13b9cbd6**
```
~ $ id
uid=65532(nonroot) gid=65532(nonroot)
~ $ pwd
/home/nonroot
~ $ ls -lah
total 27M
drwxr-xr-x    1 root     root        4.0K Oct  7 08:26 .
drwxr-xr-x    1 root     root        4.0K Oct  7 08:27 ..
-rwxr-xr-x    1 root     root       27.2M Oct  7 08:26 bucketrepo
-rw-r--r--    1 root     root         279 Oct  7 08:26 config.yaml
```

Fixes #42 - the workaround that used to work will work again.