### PR TITLE
feat: add deployment secret env vars

### DIFF
--- a/charts/bucketrepo/templates/deployment.yaml
+++ b/charts/bucketrepo/templates/deployment.yaml
@@ -34,6 +34,15 @@ spec:
         - name: {{ $pkey }}
           value: {{ quote $pval }}
 {{- end }}
+{{- if .Values.envSecrets }}
+{{- range $pkey, $pval := .Values.envSecrets }}
+        - name: {{ $pkey }}
+          valueFrom:
+            secretKeyRef:
+              name: jenkins-x-bucketrepo-env
+              key: {{ $pkey }}
+{{- end }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/charts/bucketrepo/templates/env-secret.yaml
+++ b/charts/bucketrepo/templates/env-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.envSecrets }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: jenkins-x
+  name: jenkins-x-bucketrepo-env
+stringData:
+{{- range $pkey, $pval := .Values.envSecrets }}
+  {{ $pkey }}: {{ quote $pval }}
+{{- end }}
+{{- end }}

--- a/charts/bucketrepo/values.yaml
+++ b/charts/bucketrepo/values.yaml
@@ -21,6 +21,16 @@ serviceaccount:
 # define environment variables here as a map of key: value
 env: {}
 
+# define environment variables that will be stored in a secret namd 'jenkins-x-bucketrepo-env'
+#
+# example
+#
+# envSecrets:
+#   AWS_ACCESS_KEY: xxx
+#   AWS_SECRET_KEY: yyy
+#
+envSecrets: {}
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
Add support to the helm chart to define  deployemnt environment variables using a secret.  All env secrets will be stored in a secret named jenkins-x-bucketrepo-env

The reason for needing this is to support using minio which as far as I know doesn't support IRSA

To use minio you can configure bucketrepo like the following :

bucketrepo-values.yaml
```
envSecrets:
  AWS_ACCESS_KEY: "some key"
  AWS_SECRET_KEY: "some value"
```

jx-requirements.yml
```
storage:
  - name: repository
    url: s3://jx3/bucketrepo?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
```